### PR TITLE
12 fix dockerfile failing installing cloudflared

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,16 +29,13 @@ dockers:
     dockerfile: Dockerfile
     build_flag_templates:
       - "--pull"
-      # Labels for OCI image
+      - "--platform=linux/amd64,linux/arm64"
+      # OCI image labels
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source=https://github.com/stupside/moley"
-      # Multi-platform builds
-      - "--platform=linux/amd64,linux/arm64"
-      # Build flags for Go binaries
-      - "--build-arg=LDFLAGS=-s -w -X 'github.com/stupside/moley/internal/version.Commit={{.Commit}}' -X 'github.com/stupside/moley/internal/version.BuildTime={{.Date}}' -X 'github.com/stupside/moley/internal/version.Version={{.Version}}'"
 
 changelog:
   sort: asc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,26 @@
 # GoReleaser Dockerfile - uses pre-built binaries from build context
-FROM alpine:latest
+
+# Builder stage for cloudflared
+FROM golang:1.24.5-alpine3.22 AS cloudflared
+
+# Install build dependencies
+RUN apk --no-cache add \
+    git \
+    make \
+    gcc \
+    musl-dev
+
+# Clone cloudflared repository
+RUN git clone --depth 1 https://github.com/cloudflare/cloudflared.git /go/src/cloudflared
+
+# Set the working directory for cloudflared build
+WORKDIR /go/src/cloudflared
+
+# Build cloudflared from latest
+RUN make cloudflared
+
+# Final runtime stage
+FROM alpine:latest AS runtime
 
 # Use buildx automatic platform detection for multi-arch builds
 ARG TARGETARCH


### PR DESCRIPTION
Cloudflared installation was not working as expected, so I will build Cloudflared directly in Docker instead.
Additionally, there was an error while resolving the moley binary built by GoReleaser, due to our use of multi-platform builds with buildx.